### PR TITLE
I've updated the Renovate configuration (`renovate.json`) to:

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run type check
+        run: npm run build
+
       - name: Run tests
         run: npm test

--- a/renovate.json
+++ b/renovate.json
@@ -7,9 +7,17 @@
   },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": ["FROM node:(.*?)-alpine"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "npm"
     }
   ]
 }

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -9,7 +9,7 @@ import {
   logUploadError,
   TWITTER,
   YOUTUBE,
-  PLATFORMS,
+  ALL_PLATFORMS,
 } from '../src/db'; // Assuming PLATFORMS is exported or reconstruct it
 import type { Database } from 'sqlite';
 
@@ -95,11 +95,11 @@ describe('db.ts', () => {
     const videoId2 = 'onePlatformVideo';
     const platformId = 'platformSpecificId';
     // Assuming PLATFORMS constant contains all relevant platforms, e.g. [TWITTER, YOUTUBE]
-    // If PLATFORMS is not exported from db.ts, define it locally for the test.
-    const currentPlatforms = [TWITTER, YOUTUBE]; // Or import PLATFORMS from '../src/db' if available
+    // If ALL_PLATFORMS is not exported from db.ts, define it locally for the test.
+    // const currentPlatforms = [TWITTER, YOUTUBE]; // Or import ALL_PLATFORMS from '../src/db' if available
 
     it('should return true if video is uploaded to all defined platforms', async () => {
-      for (const platform of currentPlatforms) {
+      for (const platform of ALL_PLATFORMS) {
         await saveUpload(dbInstance, videoId1, platform, platformId);
       }
       expect(await isUploadedToAllPlatforms(dbInstance, videoId1)).toBe(true);

--- a/src/has-sound.test.ts
+++ b/src/has-sound.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
 import {
   hasAudioTrack,
   areAudioLevelsAudible,
@@ -17,21 +17,36 @@ let ffmpegInstanceErrorCallback: ((err: Error) => void) | null = null;
 
 // This object holds the state and mock methods for the ffmpeg instance.
 // Tests will configure this object.
-const ffmpegInstanceConfig = {
+
+// Define an interface for the mock ffmpeg instance to type `this`
+interface MockFfmpegInstance {
+  _shouldSucceed: boolean;
+  _stderr: string;
+  _stdout: string;
+  _errorMessage: string;
+  audioFilters: Mock<() => MockFfmpegInstance>;
+  outputOptions: Mock<() => MockFfmpegInstance>;
+  output: Mock<() => MockFfmpegInstance>;
+  on: Mock<(event: string, callback: (...args: any[]) => void) => MockFfmpegInstance>;
+  run: Mock<() => void>;
+  // Add any other methods or properties that are accessed on this mock
+}
+
+const ffmpegInstanceConfig: MockFfmpegInstance = {
   _shouldSucceed: true,
   _stderr: '',
   _stdout: '',
   _errorMessage: 'Simulated ffmpeg process error',
-  audioFilters: vi.fn(function () {
+  audioFilters: vi.fn(function (this: MockFfmpegInstance) {
     return this;
   }),
-  outputOptions: vi.fn(function () {
+  outputOptions: vi.fn(function (this: MockFfmpegInstance) {
     return this;
   }),
-  output: vi.fn(function () {
+  output: vi.fn(function (this: MockFfmpegInstance) {
     return this;
   }),
-  on: vi.fn(function (event: string, callback: (...args: any[]) => void) {
+  on: vi.fn(function (this: MockFfmpegInstance, event: string, callback: (...args: any[]) => void) {
     if (event === 'end') {
       ffmpegInstanceEndCallback = callback as (
         stdout: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node", "vitest"],                        /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
1.  Enable automerge for major dependency updates: The `packageRules` were modified to include "major" in `matchUpdateTypes`. This allows Renovate to automerge major version updates for packages v1.0.0 and above, provided that status checks (like tests and builds) pass.

2.  Manage Node.js version in Dockerfile: A new regex manager was added to detect and update the Node.js version specified in the `FROM` instruction in the `Dockerfile`. It uses the `npm` datasource to track available Node.js versions.