### PR TITLE
Fix: Update regexManager in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "regexManagers": [
     {
       "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": ["FROM node:(.*?)-alpine"],
+      "matchStrings": ["FROM node:(?<currentValue>.*?)-alpine"],
       "depNameTemplate": "node",
       "datasourceTemplate": "npm"
     }


### PR DESCRIPTION
The regexManager for Dockerfile was missing a named capturing group for the current value. This commit updates the regex to name the group 'currentValue', resolving the Renovate configuration error.