### PR TITLE
Fix CI build errors and Deno installation on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:25-alpine
 
-RUN apk add --no-cache ffmpeg python3 py3-setuptools make g++ curl unzip
+RUN apk add --no-cache ffmpeg python3 py3-setuptools make g++ curl unzip libc6-compat
 
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh
 ENV DENO_INSTALL="/root/.deno"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "node16" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "node16" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
Fixed CI failures by:
1. Setting `rootDir: "./src"` in `tsconfig.json` to resolve the TypeScript error `TS5011` which was blocking the build.
2. Adding `libc6-compat` to the `Dockerfile` to fix Deno installation on the Alpine-based Node.js image, which is required for `yt-dl` to function properly.

Build and tests verified locally.

---
*PR created automatically by Jules for task [4189862168643332423](https://jules.google.com/task/4189862168643332423) started by @clentfort*